### PR TITLE
add user/pass to git clone

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,8 +156,8 @@ func getGrade(percentage float64) Grade {
 
 func newChecksResp(repo string, forceRefresh bool) (checksResp, error) {
 	url := repo
-	if !strings.HasPrefix(url, "https://github.com/") {
-		url = "https://github.com/" + url
+	if !strings.HasPrefix(url, "https://gojp:gojp@github.com/") {
+		url = "https://gojp:gojp@github.com/" + url
 	}
 
 	if !forceRefresh {


### PR DESCRIPTION
@hermanschaaf I thought of this while trying to figure out a way to check whether GitHub is prompting us for a username/password. If we clone the repo like this and it's a private repo, it will always say authentication failed, but if it's a public repo it'll clone it.