### PR TITLE
Fixed splitting lines on colons when line includes eg i := range.

### DIFF
--- a/check/utils.go
+++ b/check/utils.go
@@ -91,20 +91,25 @@ func getFileSummary(filename, dir, cmd, out string) (FileSummary, error) {
 	}
 	split := strings.Split(string(out), "\n")
 	for _, sp := range split[0 : len(split)-1] {
-		parts := strings.Split(sp, ":")
 		msg := sp
-		if cmd != "gocyclo" {
-			msg = parts[len(parts)-1]
+		var loc string
+		if cmd == "gocyclo" {
+			s := strings.SplitN(sp, " ", 2)
+			loc = s[1]
+		} else {
+			s := strings.SplitN(sp, ": ", 2)
+			loc = s[0]
+			if len(s) > 1 {
+				msg = s[1]
+			}
 		}
+
 		e := Error{ErrorString: msg}
 		switch cmd {
 		case "golint", "gocyclo", "vet":
-			ls := strings.Split(sp, ":")
-			if len(ls) >= 2 && strings.Contains(sp, filename) {
+			ls := strings.Split(loc, ":")
+			if len(ls) >= 1 && strings.Contains(loc, filename) {
 				idx := len(ls) - 2
-				if cmd == "golint" {
-					idx = len(ls) - 3
-				}
 				if cmd == "vet" {
 					idx = 1
 				}


### PR DESCRIPTION
This fix corrects the following issue:

When golint returned a line such as:
``file.go:83:9: should omit 2nd value from range; this loop is equivalent to `for i := range ...` ``

because of the additional colon, which is used for splitting, goreportcard would display:
`Line 9: = range ...`

instead of:
``Line 83: should omit 2nd value from range; this loop is equivalent to `for i := range ...` ``
