### PR TITLE
Add skipSuffixes variable and add initial suffixes

### DIFF
--- a/check/testfiles/a.pb.go
+++ b/check/testfiles/a.pb.go
@@ -1,0 +1,1 @@
+package testfiles

--- a/check/testfiles/a.pb.gw.go
+++ b/check/testfiles/a.pb.gw.go
@@ -1,0 +1,1 @@
+package testfiles

--- a/check/utils.go
+++ b/check/utils.go
@@ -12,7 +12,10 @@ import (
 	"syscall"
 )
 
-var skipDirs = []string{"Godeps", "vendor", "third_party"}
+var (
+	skipDirs     = []string{"Godeps", "vendor", "third_party"}
+	skipSuffixes = []string{".pb.go", ".pb.gw.go"}
+)
 
 // GoFiles returns a slice of Go filenames
 // in a given directory.
@@ -31,7 +34,13 @@ func GoFiles(dir string) ([]string, error) {
 		if fi.IsDir() {
 			return nil // not a file.  ignore.
 		}
-		ext := filepath.Ext(fi.Name())
+		fiName := fi.Name()
+		for _, skip := range skipSuffixes {
+			if strings.HasSuffix(fiName, skip) {
+				return nil
+			}
+		}
+		ext := filepath.Ext(fiName)
 		if ext == ".go" {
 			filenames = append(filenames, fp)
 		}


### PR DESCRIPTION
I have a lot of repositories with generated protobuf files, such as:

https://go.pedge.io/openflights
https://go.pedge.io/flightaware
https://go.pedge.io/protoeasy
...

In all of these, I take pains to ignore the generated `.pb.go` files (and generated `.pb.gw.go` files from https://github.com/gengo/grpc-gateway) https://github.com/peter-edge/go-openflights/blob/0a97dbbd1609a1483183009e7158594a346211cf/Makefile#L27

Tools like golint etc say they are suggestions, and do not always apply. I think generated code is exactly such a situation - I have little control over code that is generated from a third party that I use, and it's understood that it does not necessarily go by golang conventions. Giving a report card to a repo should in general not depend on code generated by third party tools.

To help this, I added this simple mechanism to ignore suffixes of files (`filepath.Ext(...)` just gets the actual extension). I added the two above, which are widely used, but if others have known generated code suffixes, this would be a place to add them in the future.

Thoughts?