### PR TITLE
Allow license.code

### DIFF
--- a/check/license.go
+++ b/check/license.go
@@ -23,7 +23,7 @@ func (g License) Weight() float64 {
 
 // thank you https://github.com/ryanuber/go-license
 var licenses = []string{
-	"license", "license.txt", "license.md",
+	"license", "license.txt", "license.md", "license.code",
 	"copying", "copying.txt", "copying.md",
 	"unlicense",
 }


### PR DESCRIPTION
I've seen a few repo when code and docs have different license, like github.com/docker/swarm

Might we add license.code to the list ?