### PR TITLE
Properly update the golang package, #83

### DIFF
--- a/handlers/checks.go
+++ b/handlers/checks.go
@@ -85,7 +85,7 @@ func goGet(repo string) error {
 	os.Setenv("GOPATH", d)
 	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {
-		cmd := exec.Command("go", "get", "-d", repo)
+		cmd := exec.Command("go", "get", "-d", "-u", repo)
 		cmd.Stdout = os.Stdout
 		stderr, err := cmd.StderrPipe()
 		if err != nil {


### PR DESCRIPTION
This PR should properly update the golang package on refresh.

https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies

"The -u flag instructs get to use the network to update the named packages and their dependencies. By default, get uses the network to check out missing packages but does not use it to look for updates to existing packages."
