### PR TITLE
Install misspell when installing other dependencies.

### DIFF
--- a/scripts/make-install.sh
+++ b/scripts/make-install.sh
@@ -4,3 +4,4 @@ go get github.com/tools/godep
 
 go get github.com/alecthomas/gometalinter
 gometalinter --install --update
+go get github.com/client9/misspell/cmd/misspell


### PR DESCRIPTION
Misspell was not installed with the other dependencies during `make install`, this change adds it.