### PR TITLE
Dockerfile fixes/optimizations.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.6
-
-RUN go get golang.org/x/tools/go/vcs
+FROM golang:1.6-alpine
 
 COPY . $GOPATH/src/github.com/gojp/goreportcard
 
 WORKDIR $GOPATH/src/github.com/gojp/goreportcard
 
-EXPOSE 8080
+RUN apk update && apk upgrade && apk add --no-cache git make \
+        && go get golang.org/x/tools/go/vcs \
+        && ./scripts/make-install.sh
+
+EXPOSE 8000
 
 CMD ["make", "start"]

--- a/scripts/make-install.sh
+++ b/scripts/make-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 go get github.com/alecthomas/gometalinter
 gometalinter --install --update


### PR DESCRIPTION
The Dockerfile included in goreportcard's repo produces an image without gometalinter, which in turn gives the following errors in the runtime:

```
ERROR: (errcheck) exec: "gometalinter": executable file not found in $PATH
ERROR: (gofmt) exec: "gometalinter": executable file not found in $PATH
ERROR: (go_vet) exec: "gometalinter": executable file not found in $PATH
ERROR: (golint) exec: "gometalinter": executable file not found in $PATH
ERROR: (gocyclo) exec: "gometalinter": executable file not found in $PATH
ERROR: (misspell) exec: "gometalinter": executable file not found in $PATH
ERROR: (ineffassign) exec: "gometalinter": executable file not found in $PATH
```

This PR fixes that.

And also, by using `golang:1.6-alpine` instead of `golang:1.6`, the size of the resulting image can be drastically reduced (461 MB in the former case vs. 914 MB in the latter).
