### PR TITLE
Follow redirects for "vanity imports"

### DIFF
--- a/handlers/checks.go
+++ b/handlers/checks.go
@@ -70,6 +70,7 @@ type checksResp struct {
 	Files                int       `json:"files"`
 	Issues               int       `json:"issues"`
 	Repo                 string    `json:"repo"`
+	ResolvedRepo         string    `json:"resolvedRepo"`
 	LastRefresh          time.Time `json:"last_refresh"`
 	HumanizedLastRefresh string    `json:"humanized_last_refresh"`
 }
@@ -143,6 +144,7 @@ func newChecksResp(repo string, forceRefresh bool) (checksResp, error) {
 
 	resp := checksResp{
 		Repo:                 repo,
+		ResolvedRepo:         repoRoot.Repo,
 		Files:                len(filenames),
 		LastRefresh:          time.Now().UTC(),
 		HumanizedLastRefresh: humanize.Time(time.Now().UTC()),

--- a/templates/report.html
+++ b/templates/report.html
@@ -214,7 +214,8 @@
       return percentage == false;
     });
 
-    var allowedLinkDomains = ["github.com/", "bitbucket.org/", "golang.org/"];
+    var allowedLinkDomains = ["https://github.com/", "https://bitbucket.org/",
+      "https://golang.org/", "https://go.googlesource.com/"];
 
     // initialize handlebars templates
     var templates = {};
@@ -235,8 +236,8 @@
         var $resultsDetails = $('.results-details').empty();
 
         for (var i = 0; i < allowedLinkDomains.length; i++) {
-          if (data.repo.indexOf(allowedLinkDomains[i]) == 0) {
-            data.link = "https://" + data.repo;
+          if (data.resolvedRepo.indexOf(allowedLinkDomains[i]) == 0) {
+            data.link = data.resolvedRepo;
           }
         }
         data.use_an = data.grade == "A" || data.grade == "A+";


### PR DESCRIPTION
e.g. if you have:

```
<meta name="go-import" content="arp242.net/sconfig git https://github.com/Carpetsmoker/sconfig.git">
```

then the repo isn't linked; this fixes that by using the resolved destination,
rather than the path the user entered.
