### PR TITLE
Add option to hide repos from the recently generated list

### DIFF
--- a/assets/goreportcard.css
+++ b/assets/goreportcard.css
@@ -1,3 +1,16 @@
+.clearfix:before, .clearfix:after {
+    content: ' ';
+    display: table;
+}
+.clearfix:after {
+    clear: both;
+}
+.pull-left {
+    float: left;
+}
+.pull-right {
+    float: right;
+}
 .header .is-active {
     font-weight: bold;
 }
@@ -18,8 +31,22 @@
     min-width: 350px;
 }
 #check_form .btn-test {
-    margin-top: 1em;
+    margin-top: 0.5em;
     font-weight: 200;
+}
+.ghost-mode {
+    display: table;
+    font-size: 11px;
+    margin: 0 auto;
+    margin-top: 0.7em;
+}
+.ghost-mode input {
+    vertical-align: middle;
+}
+.ghost-mode span {
+    display: inline-block;
+    padding-left: 6px;
+    padding-top: 1px;
 }
 .header-item #check_form .input-box {
     padding: 3px;

--- a/templates/home.html
+++ b/templates/home.html
@@ -63,6 +63,20 @@
               <input name="repo" type="text" class="input-box" placeholder="github.com/gojp/goreportcard"/>
             </p>
           </div>
+
+          <div class="ghost-mode clearfix">
+            <label>
+              <div class="pull-left">
+                <input type="hidden" name="ghost" value="false" />
+                <input type="checkbox" name="ghost" value="true" />
+              </div>
+
+              <div class="pull-right">
+                <span>Do not show the results on the boards</span>
+              </div>
+            </label>
+          </div>
+
           <div>
             <button type="submit" class="button btn-test is-large" href="#" role="button">Generate Report</button>
           </div>


### PR DESCRIPTION
This option allows users to decide if a repository will be displayed in the "Recently Generated" box. People might want to use the web service to check their semi-private or experimental projects but keep their existence in private. Notice that by default the "Recently Generated" list serves as a way to spam visitors in order to make them check non-relevant repositories. I will keep this option as an opt-in instead of opt-out for backward compatibility.

When I built the [Sucuri Performance](https://performance.sucuri.net/) tool people started to spam the service by sending requests to the API so their websites (usually NSFW links) could appear in the _"recently"_ boxes hoping that it would increase the traffic. We ended up adding a cache mechanism to show the links only to the connections associated to the request for a short period of time while a background service was filtering inappropriate content. This cannot be implemented here but the use case explained above is still valid.

![zzz](https://cloud.githubusercontent.com/assets/1933999/19943179/488382b0-a104-11e6-93da-291b6718552f.png)
