### PR TITLE
Todofinder

### DIFF
--- a/assets/goreportcard.css
+++ b/assets/goreportcard.css
@@ -49,6 +49,9 @@ time {
 .percentage.success {
     color: #4CC61E;
 }
+.percentage.misc {
+    color: blue;
+}
 .results-text {
     font-size: 1.4em;
 }

--- a/check/testfiles/todo_cases.txt
+++ b/check/testfiles/todo_cases.txt
@@ -1,0 +1,20 @@
+todo
+TODO
+Todo
+//todo
+//Todo
+//TODO
+// TODO
+// todo
+// Todo
+
+
+todos
+TODOs
+Todos
+//todos
+//Todos
+//TODOs
+// TODOs
+// todos
+// Todos

--- a/check/todofinder.go
+++ b/check/todofinder.go
@@ -27,10 +27,11 @@ var regex = "(\\/\\/.*\\b(?i)todo(?-i)\\b)"
 var todoRegex, err = regexp.Compile(regex)
 
 //Percentage returns files with todo comments
-func (g TodoFinder) Percentage() (percentage float64, fs []FileSummary, err error) {
+func (g TodoFinder) Percentage() (todosCount float64, fs []FileSummary, err error) {
 
 	for _, file := range g.Filenames {
 		todosInFile, _ := findTodosInFile(file)
+		todosCount += float64(len(todosInFile))
 		if len(todosInFile) != 0 {
 			filename := strings.TrimPrefix(file, "_repos/src")
 			fs = append(fs, FileSummary{Filename: makeFilename(filename),
@@ -42,7 +43,7 @@ func (g TodoFinder) Percentage() (percentage float64, fs []FileSummary, err erro
 	if err != nil {
 		return 0.0, []FileSummary{}, err
 	}
-	return 1.0, fs, err
+	return float64(todosCount), fs, err
 }
 
 //Description returns the description of TodoFinder

--- a/check/todofinder.go
+++ b/check/todofinder.go
@@ -1,0 +1,80 @@
+package check
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+)
+
+//TodoFinder is th check for the todos in comments
+type TodoFinder struct {
+	Dir       string
+	Filenames []string
+}
+
+//Name returns the name of the display name of the command
+func (g TodoFinder) Name() string {
+	return "todofinder"
+}
+
+//Weight returns the weight this check has in the overall average
+func (g TodoFinder) Weight() float64 {
+	return 0
+}
+
+var regex = "(\\/\\/.*\\b(?i)todo(?-i)\\b)"
+var todoRegex, err = regexp.Compile(regex)
+
+//Percentage returns files with todo comments
+func (g TodoFinder) Percentage() (percentage float64, fs []FileSummary, err error) {
+
+	for _, file := range g.Filenames {
+		todosInFile, _ := findTodosInFile(file)
+		if len(todosInFile) != 0 {
+			filename := strings.TrimPrefix(file, "_repos/src")
+			fs = append(fs, FileSummary{Filename: makeFilename(filename),
+				FileURL: fileURL(g.Dir, strings.TrimPrefix(file, "_repos/src")),
+				Errors:  todosInFile})
+
+		}
+	}
+	if err != nil {
+		return 0.0, []FileSummary{}, err
+	}
+	return 1.0, fs, err
+}
+
+//Description returns the description of TodoFinder
+func (g TodoFinder) Description() string {
+	return "Todofinder finds todos in comments"
+}
+
+func readLinesFromFile(filename string) ([]string, error) {
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0660)
+	defer f.Close()
+
+	if err != nil {
+		return nil, err
+	}
+	sc := bufio.NewScanner(f)
+	lines := []string{}
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines, sc.Err()
+}
+
+func findTodosInFile(filename string) (todos []Error, err error) {
+	fileLines, err := readLinesFromFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	for i, line := range fileLines {
+		if todoRegex.FindString(line) != "" {
+			newTodo := Error{i + 1, line}
+			todos = append(todos, newTodo)
+		}
+	}
+	return todos, nil
+}

--- a/check/todofinder_test.go
+++ b/check/todofinder_test.go
@@ -1,0 +1,29 @@
+package check
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestErrors(t *testing.T) {
+	_, err := readLinesFromFile("testfiles/notexists.go")
+
+	if err == nil {
+		t.Errorf("Doesn't throw error!")
+	}
+}
+func TestTodoPercentage(t *testing.T) {
+	repoDir := "../_repos/src/github.com/docker"
+	filenames, _, _ := GoFiles(repoDir)
+	p := TodoFinder{repoDir, filenames}
+	todos, _, error := p.Percentage()
+	fmt.Println(todos, error)
+}
+func TestRegex(t *testing.T) {
+	returnedTodos, _ := findTodosInFile("testfiles/todo_cases.txt")
+	t.Log(returnedTodos)
+	currentCases := 6
+	if len(returnedTodos) != currentCases {
+		t.Errorf("Expected: %v ; Got: %v ", currentCases, len(returnedTodos))
+	}
+}

--- a/handlers/checks.go
+++ b/handlers/checks.go
@@ -121,6 +121,7 @@ func newChecksResp(repo string, forceRefresh bool) (checksResp, error) {
 		check.Misspell{Dir: dir, Filenames: filenames},
 		check.IneffAssign{Dir: dir, Filenames: filenames},
 		// check.ErrCheck{Dir: dir, Filenames: filenames}, // disable errcheck for now, too slow and not finalized
+		check.TodoFinder{Dir: dir, Filenames: filenames},
 	}
 
 	ch := make(chan score)

--- a/templates/report.html
+++ b/templates/report.html
@@ -117,7 +117,11 @@
   <script id="template-check" type="text/x-handlebars-template">
       <a class="panel-block" href="#{{{name}}}">
         {{{name}}}
+        {{#ifEquals name "todofinder"}}
+        <span class="percentage misc">{{percentage}}</span>
+        {{else}}
         <span class="percentage {{color percentage}}">{{percentage}}%</span>
+        {{/ifEquals}}
       </a>
   </script>
   <script id="template-badgedropdown" type="text/x-handlebars-template">
@@ -132,7 +136,12 @@
   </script>
   <script id="template-details" type="text/x-handlebars-template">
     <div class="wrapper">
+      
+      {{#ifEquals name "todofinder"}}
+      <a name="{{{name}}}"></a><h1 class="tool-title">{{{name}}}<span class="percentage misc">{{percentage}}</span></h1>
+      {{else}}
       <a name="{{{name}}}"></a><h1 class="tool-title">{{{name}}}<span class="percentage {{color percentage}}">{{percentage}}%</span></h1>
+      {{/ifEquals}}
       <p class="tool-description">{{{description}}}</p>
     {{#if error}}
         <p class="error-msg">An error occurred while running this test ({{error}})</p>
@@ -202,6 +211,10 @@
       return percentage == false;
     });
 
+    Handlebars.registerHelper('ifEquals', function(arg1, arg2, options) {
+    return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
+});
+
     var allowedLinkDomains = ["https://github.com/", "https://bitbucket.org/",
       "https://golang.org/", "https://go.googlesource.com/"];
 
@@ -233,8 +246,13 @@
         $resultsText.html($(templates.grade(data)));
         var $table = $(".results");
         $table.html('<p class="panel-heading">Results</p>');
+        console.log(checks)
         for (var i = 0; i < checks.length; i++) {
-            checks[i].percentage = parseInt(checks[i].percentage * 100.0);
+
+            
+            if (checks[i].name!="todofinder"){
+            checks[i].percentage = parseInt(checks[i].percentage*100.0);
+            }
             var $headRow = $(templates.check(checks[i]));
             $headRow.on("click", function(){
             $(this).closest("nav").find(".is-active").removeClass("is-active");
@@ -250,6 +268,8 @@
         }
         $(".container-suggestions").addClass('hidden');
         $(".container-results").removeClass('hidden').slideDown();
+
+        
 
         $lastRefresh = $(templates.lastrefresh(data));
         $div = $(".container-update").html($lastRefresh);


### PR DESCRIPTION
This the pull request for the issue #62 , adding a TODO count. I selected this improvement because it doesn't interfere with the report grade and IMHO better for a golang newcomer. 

This pull request adds a new check called `todofinder` to the `check` package. 

### Backend
Backend of `Todofinder`struct comes with 3 new files and edits the *handler/checks.go* to add the todofinder to reporting process. New files are:

**todofinder.go** Main logic. It reads lines from gofiles, finds *todos* in comment form(`// TODO`) and returns the todo count. It is not a percentage-wise operation so returning todo counts seems better. It finds the todos using a regex.

**todofinder_test.go** Unit testing for todofinder. Covers all statements except Name(),Weight(),Description() and some error returns. This test class uses the docker repo(`../_repos/src/github.com/docker`) for the percentage() integration test. 

**todo_cases.txt** Some test cases for todofinder. It returns 6 todos from this file, lines 4-9.

### Frontend
Frontend of the `Todofinder` edits *report.html* and *goreportcard.css*.

**report.html** Because todofinder is returning todocount I edited the results view to show the returned value without the percentage sign(`%`). I added a handlebars helper. The helper checks whether the check[i] has the name "todofinder". If it does, it renders it differently. This helper can also be used for the licence check e.g. to change the result to `yes` or `no`.

**goreportcard.csss** I added the color blue to use for my todocount result.

Some pictures:
<img width="233" alt="screen shot 2017-11-15 at 22 21 38" src="https://user-images.githubusercontent.com/7947572/32860933-78efb918-ca53-11e7-8f7f-945701380027.png">
<img width="751" alt="screen shot 2017-11-15 at 22 22 00" src="https://user-images.githubusercontent.com/7947572/32860935-7b352df2-ca53-11e7-9e95-e85476d86bd9.png">

Because both misspell and todofinder have weight 0, sometimes todofinder is before, sometimes after the misspell.

### Performance: 
`todofinder` is never the bottleneck at the checks in any repo. I added some time calculation code to different checks(and removed them) to see whether they wait for todofinder. Todofinder finished almost in all cases under 1 second (1.3 for very large repos,never 2) and is one of the first checks to end. It closes the files it has opened.  

I'm really exited for this pull request as it will be my first PR.
 