### PR TITLE
Fixing megacheck issues reported by gometalinter

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -84,6 +84,9 @@ func download(path, dest string, firstAttempt bool) (root *vcs.RepoRoot, err err
 		// may have been rebased; we delete the directory, then try one more time:
 		log.Printf("Failed to update %q (%v), trying again...", root.Repo, err.Error())
 		err = os.RemoveAll(fullLocalPath)
+		if err != nil {
+			log.Printf("Failed to delete directory %s", fullLocalPath)
+		}
 		return download(path, dest, false)
 	}
 	return root, err

--- a/handlers/about.go
+++ b/handlers/about.go
@@ -11,5 +11,4 @@ func AboutHandler(w http.ResponseWriter, r *http.Request) {
 	t.Execute(w, map[string]interface{}{
 		"google_analytics_key": googleAnalyticsKey,
 	})
-	return
 }

--- a/handlers/badge.go
+++ b/handlers/badge.go
@@ -49,8 +49,7 @@ func badgePath(grade Grade, style string, dev bool) string {
 
 // BadgeHandler handles fetching the badge images
 func BadgeHandler(w http.ResponseWriter, r *http.Request, repo string, dev bool) {
-	name := fmt.Sprintf("%s", repo)
-	resp, err := newChecksResp(name, false)
+	resp, err := newChecksResp(repo, false)
 
 	// See: http://shields.io/#styles
 	style := r.URL.Query().Get("style")
@@ -59,7 +58,7 @@ func BadgeHandler(w http.ResponseWriter, r *http.Request, repo string, dev bool)
 	}
 
 	if err != nil {
-		log.Printf("ERROR: fetching badge for %s: %v", name, err)
+		log.Printf("ERROR: fetching badge for %s: %v", repo, err)
 		url := "https://img.shields.io/badge/go%20report-error-lightgrey.svg?style=" + style
 		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 		return

--- a/handlers/check.go
+++ b/handlers/check.go
@@ -51,7 +51,6 @@ func CheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Write(b)
-	return
 }
 
 func updateHighScores(mb *bolt.Bucket, resp checksResp, repo string) error {
@@ -96,12 +95,7 @@ func updateHighScores(mb *bolt.Bucket, resp checksResp, repo string) error {
 	if err != nil {
 		return err
 	}
-	err = mb.Put([]byte("scores"), scoreBytes)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return mb.Put([]byte("scores"), scoreBytes)
 }
 
 func updateReposCount(mb *bolt.Bucket, repo string) (err error) {
@@ -155,12 +149,7 @@ func updateRecentlyViewed(mb *bolt.Bucket, repo string) error {
 	if err != nil {
 		return err
 	}
-	err = mb.Put([]byte("recent"), b)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return mb.Put([]byte("recent"), b)
 }
 
 //func updateMetadata(tx *bolt.Tx, resp checksResp, repo string, isNewRepo bool, oldScore *float64) error {

--- a/tools/clean-repos/main.go
+++ b/tools/clean-repos/main.go
@@ -26,7 +26,7 @@ func main() {
 			}
 			for _, d := range dirs {
 				path := "_repos/src/" + f.Name() + "/" + d.Name()
-				if time.Now().Sub(d.ModTime()) > 30*24*time.Hour {
+				if time.Since(d.ModTime()) > 30*24*time.Hour {
 					if *real {
 						log.Printf("Deleting %s (repo is old)...", path)
 						os.RemoveAll(path)

--- a/tools/db/manage_db.go
+++ b/tools/db/manage_db.go
@@ -56,12 +56,7 @@ func deleteRepo(repo string) error {
 			return err
 		}
 
-		err = mb.Put([]byte("scores"), scoreBytes)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return mb.Put([]byte("scores"), scoreBytes)
 	})
 
 }
@@ -110,7 +105,7 @@ func listDuplicates() error {
 
 func main() {
 	flag.Parse()
-	if *repo == "" && *listDupes == false {
+	if *repo == "" && !*listDupes {
 		log.Println("Usage: manage_db.go [-list-duplicates] [-remove repo]")
 		return
 	}

--- a/tools/names/migrate_repo_names.go
+++ b/tools/names/migrate_repo_names.go
@@ -75,12 +75,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		err = mb.Put([]byte("scores"), scoreBytes)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return mb.Put([]byte("scores"), scoreBytes)
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/tools/scores/init_repo_scores.go
+++ b/tools/scores/init_repo_scores.go
@@ -10,10 +10,7 @@ import (
 	"github.com/gojp/goreportcard/handlers"
 )
 
-const (
-	repoBucket string = "repos"
-	metaBucket string = "meta"
-)
+const repoBucket = "repos"
 
 type checksResp struct {
 	Repo    string  `json:"repo"`


### PR DESCRIPTION
Fixes the following issues reported : 

> check/utils.go:375:25:warning: HasSuffix is a pure function but its return value is ignored (SA4017) (megacheck)
> download/download.go:86:3:warning: this value of err is never used (SA4006) (megacheck)
> handlers/about.go:14:2:warning: redundant return statement (S1023) (megacheck)
> handlers/badge.go:52:10:warning: the argument is already a string, there's no need to use fmt.Sprintf (S1025) (megacheck)
> handlers/check.go:54:2:warning: redundant return statement (S1023) (megacheck)
> handlers/check.go:100:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (megacheck)
> handlers/check.go:159:2:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (megacheck)
> tools/clean-repos/main.go:29:8:warning: should use time.Since instead of time.Now().Sub (S1012) (megacheck)
> tools/db/manage_db.go:60:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (megacheck)
> tools/db/manage_db.go:60:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (megacheck)
> tools/db/manage_db.go:113:20:warning: should omit comparison to bool constant, can be simplified to !*listDupes (S1002) (megacheck)
> tools/names/migrate_repo_names.go:79:3:warning: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013) (megacheck)
> tools/scores/init_repo_scores.go:15:2:warning: const metaBucket is unused (U1000) (megacheck)
