### PR TITLE
GitHub hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ When running the site in a production environment, instead of `make start-dev`, 
 make start
 ```
 
+### Integration
+
+#### GitHub
+`/github/hook` accepts `application/json` GitHub hook POST, and refreshs go package located at
+`"github.com/" + payload.repository.full_name`.
+
+#### Others
+`/check` accepts `application/x-www-form-urlencoded` POST, and refreshs go package located at
+`form.repo`. In success, it write `application/json` response `{redirect: "/report/" + repositoryName}`.
+
 ### Contributing
 
 Go Report Card is an open source project run by volunteers, and contributions are welcome! Check out the [Issues](https://github.com/gojp/goreportcard/issues) page to see if your idea for a contribution has already been mentioned, and feel free to raise an issue or submit a pull request.

--- a/handlers/github.go
+++ b/handlers/github.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type githubRepository struct {
+	FullName string `json:"full_name"`
+}
+
+type githubPayload struct {
+	Repository githubRepository `json:"repository"`
+}
+
+// GithubHookHandler handles "application/json" POST request from github hooks.
+func GithubHookHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Fail to read request body: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	var payload githubPayload
+	err = json.Unmarshal(b, &payload)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("fail to unmarshal request body: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	repo := "github.com/" + payload.Repository.FullName
+	handleHTTPCheckRepo(repo, true, w)
+}

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 	http.HandleFunc(m.instrument("/assets/", handlers.AssetsHandler))
 	http.HandleFunc(m.instrument("/favicon.ico", handlers.FaviconHandler))
 	http.HandleFunc(m.instrument("/checks", handlers.CheckHandler))
+	http.HandleFunc(m.instrument("/github/hook", handlers.GithubHookHandler))
 	http.HandleFunc(m.instrument("/report/", makeHandler("report", *dev, handlers.ReportHandler)))
 	http.HandleFunc(m.instrument("/badge/", makeHandler("badge", *dev, handlers.BadgeHandler)))
 	http.HandleFunc(m.instrument("/high_scores/", handlers.HighScoresHandler))


### PR DESCRIPTION
Three commits:
* Separate methods to check repository and write http response.
   This way third party integration handlers can use these functions.
* Add HTTP handler to serve github hooks.
  This way repository in github can refresh continuously when pushing.
* Add integration guide 