### PR TITLE
Feature/tilde

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM golang:1.8-alpine
 
-COPY . $GOPATH/src/github.com/gojp/goreportcard
 
 WORKDIR $GOPATH/src/github.com/gojp/goreportcard
 
-RUN apk update && apk upgrade && apk add --no-cache git make \
-        && go get golang.org/x/tools/go/vcs \
-        && ./scripts/make-install.sh
+RUN apk update && \
+      apk upgrade && \
+      apk add --no-cache git make && \
+      go get golang.org/x/tools/go/vcs
 
 EXPOSE 8000
 
 CMD ["make", "start"]
+
+COPY . .
+
+RUN scripts/make-install.sh

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var (
 
 func makeHandler(name string, dev bool, fn func(http.ResponseWriter, *http.Request, string, bool)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		validPath := regexp.MustCompile(fmt.Sprintf(`^/%s/([a-zA-Z0-9\-_\/\.]+)$`, name))
+		validPath := regexp.MustCompile(fmt.Sprintf(`^/%s/([a-zA-Z0-9\-_\/\.][a-zA-Z0-9\-_\/\.~]*)$`, name))
 
 		m := validPath.FindStringSubmatch(r.URL.Path)
 


### PR DESCRIPTION
For self-hosted bitbucket repos owned by a user rather than a group, there is a tilde in the repo path. The clone seemed to work fine, but then loading the report itself fails as a 404.

This PR fixes the issue by allowing tildes (except as the first character, in an attempt to avoid potential directory traversal issues) in the repo url pattern.

Additionally, I rearranged the Dockerfile slightly to better utilize caching.