### PR TITLE
Docker build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.10-alpine
 
 COPY . $GOPATH/src/github.com/gojp/goreportcard
 


### PR DESCRIPTION
Update golang version from 1.8 to 1.10 to fix docker build issues as reported on #270.