### PR TITLE
Fix command for starting local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make install
 Now run
 
 ```
-make start-dev
+make start
 ```
 
 and you should see
@@ -32,12 +32,6 @@ Running on 127.0.0.1:8000...
 ```
 
 Navigate to that URL in your browser and check that you can see the front page.
-
-When running the site in a production environment, instead of `make start-dev`, run:
-
-```
-make start
-```
 
 ### Command Line Interface
 


### PR DESCRIPTION
It seems that the document is outdated. The `start-dev` command does not seem to exist in the Makefile anymore. Running the command fails:

```
make start-dev
make: *** No rule to make target `start-dev'.  Stop.
```
Is it correct to assume that the `start` command should be used for development and production environment? I change the documentation to reflect that assuming that's the case.