### PR TITLE
Add link for AsciiDoc

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -128,6 +128,9 @@
           <div>
               <label>Markdown</label><input value="[![Go Report Card]({{{image_url}}})]({{{url}}})">
           </div>
+          <div>
+              <label>AsciiDoc</label><input value="image:{{{image_url}}}[&quot;Go Report Card&quot;, link=&quot;{{{url}}}&quot;]">
+          </div>
       </div>
   </script>
   <script id="template-details" type="text/x-handlebars-template">


### PR DESCRIPTION
More and more developers switch from Markdown to AsciiDoc. The badge should offer an alternative link for embedding the report into AsciiDoc documents.