### PR TITLE
add badges assets for for-the-badge style

### DIFF
--- a/assets/badges/a+_for-the-badge.svg
+++ b/assets/badges/a+_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="125.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="41" height="28" fill="#44cc0f"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="1050" y="175" font-weight="bold" transform="scale(0.1)" textLength="170" lengthAdjust="spacing">A+</text>
+  </g>
+  
+  
+</svg>
+

--- a/assets/badges/a_for-the-badge.svg
+++ b/assets/badges/a_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="29" height="28" fill="#44cc0f"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="990" y="175" font-weight="bold" transform="scale(0.1)" textLength="50" lengthAdjust="spacing">A</text>
+  </g>
+  
+  
+</svg>
+

--- a/assets/badges/b_for-the-badge.svg
+++ b/assets/badges/b_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="29" height="28" fill="#a4a61d"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="990" y="175" font-weight="bold" transform="scale(0.1)" textLength="50" lengthAdjust="spacing">B</text>
+  </g>
+  
+  
+</svg>
+

--- a/assets/badges/c_for-the-badge.svg
+++ b/assets/badges/c_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="29" height="28" fill="#dfb315"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="990" y="175" font-weight="bold" transform="scale(0.1)" textLength="50" lengthAdjust="spacing">C</text>
+  </g>
+  
+  
+</svg>
+

--- a/assets/badges/d_for-the-badge.svg
+++ b/assets/badges/d_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="115.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="31" height="28" fill="#fe7d36"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="1000" y="175" font-weight="bold" transform="scale(0.1)" textLength="70" lengthAdjust="spacing">D</text>
+  </g>
+  
+  
+</svg>
+

--- a/assets/badges/e_for-the-badge.svg
+++ b/assets/badges/e_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="29" height="28" fill="#e05d44"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="990" y="175" font-weight="bold" transform="scale(0.1)" textLength="50" lengthAdjust="spacing">E</text>
+  </g>
+  
+  
+</svg>
+

--- a/assets/badges/f_for-the-badge.svg
+++ b/assets/badges/f_for-the-badge.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113.5" height="28">
+  <g shape-rendering="crispEdges">
+    <rect width="84.5" height="28" fill="#555"/>
+    <rect x="84.5" width="29" height="28" fill="#e05d44"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+    
+    
+      <text x="422.5" y="175" transform="scale(0.1)" textLength="605" lengthAdjust="spacing">GO REPORT</text>
+    
+    <text x="990" y="175" font-weight="bold" transform="scale(0.1)" textLength="50" lengthAdjust="spacing">F</text>
+  </g>
+  
+  
+</svg>
+


### PR DESCRIPTION
In the https://github.com/gojp/goreportcard/commit/8940f71383bfc212e7173e80f66ca55a3c0f1090, badges assets with some styles have been added. However, the style *for-the-badge* has not been added yet. Looks all the styles supported in Shield.io are supported, but actually `?style=for-the-badge` is unavailable (`404 Not Found` appears if it's specified). Some people and I surely want the style badges (See: https://github.com/gojp/goreportcard/issues/7#issuecomment-367659982 and https://github.com/gojp/goreportcard/pull/262#issuecomment-492376744).

I generated the *for-the-badge* styled badges with [gh-badges](https://github.com/badges/shields/blob/b68ac16092/gh-badges/README.md) by [Shields.io](https://github.com/badges/shields). The colors are picked from the [existing assets](https://github.com/gojp/goreportcard/tree/master/assets/badges).

<img width="617" alt="Screenshot 2020-02-10 13 30 37" src="https://user-images.githubusercontent.com/21333876/74121115-8a7bb080-4c09-11ea-8cda-69d77e5b08a3.png">
