### PR TITLE
Dockerfile: Add CLI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM golang:1.12.5-alpine
 
 RUN apk add --update --no-cache git make \
     && go get golang.org/x/tools/go/vcs
-        
+
 COPY . $GOPATH/src/github.com/gojp/goreportcard
 
 WORKDIR $GOPATH/src/github.com/gojp/goreportcard
 
 RUN ./scripts/make-install.sh
+
+RUN go build \
+    -o $GOPATH/bin/goreportcard-cli \
+    $GOPATH/src/github.com/gojp/goreportcard/cmd/goreportcard-cli
 
 EXPOSE 8000
 


### PR DESCRIPTION
Since you have a makefile available, I figured that would be the preferred place to put the build. However, since there are currently no references to GOPATH there, I put it in the Dockerfile. It might actually work better there since this is primarily serves the Docker audience, anyway, and it's already simple-enough to build it from local.

I'd recommend adding a section to the documentation explicitly mentioning that a Dockerfile is available and sharing an example of how to use it, such as:

```
Build:

$ docker build . -t go-reportcard

Run (from project path):

$ docker run -i -t -v $(pwd):/project go-reportcard /go/bin/goreportcard-cli -v -d /project
```