### PR TITLE
Update CLI output examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ goreportcard-cli
 ```
 
 ```
-Grade: A+ (99.9%)
-Files: 362
-Issues: 2
-gofmt: 100%
-go_vet: 99%
-gocyclo: 99%
-golint: 100%
-ineffassign: 100%
-license: 100%
-misspell: 100%
+Grade .......... A+  99.9%
+Files ................ 362
+Issues ................. 2
+gofmt ............... 100%
+go_vet ............... 99%
+gocyclo .............. 99%
+golint .............. 100%
+ineffassign ......... 100%
+license ............. 100%
+misspell ............ 100%
 ```
 
 Verbose output:
@@ -75,22 +75,22 @@ goreportcard-cli -v
 ```
 
 ```
-Grade: A+ (99.9%)
-Files: 332
-Issues: 2
-gofmt: 100%
-go_vet: 99%
+Grade .......... A+  99.9%
+Files ................ 362
+Issues ................. 2
+gofmt ............... 100%
+go_vet ............... 99%
 go_vet  vendor/github.com/prometheus/client_golang/prometheus/desc.go:25
         error: cannot find package "github.com/prometheus/client_model/go" in any of: (vet)
 
-gocyclo: 99%
+gocyclo .............. 99%
 gocyclo download/download.go:22
         warning: cyclomatic complexity 17 of function download() is high (> 15) (gocyclo)
 
-golint: 100%
-ineffassign: 100%
-license: 100%
-misspell: 100%
+golint .............. 100%
+ineffassign ......... 100%
+license ............. 100%
+misspell ............ 100%
 ```
 
 ### Contributing


### PR DESCRIPTION
The README now shows the grade report in justified format. This corresponds with the change eacacaa1f5ea0dba2787905cfb76eb4ae6af4e09.