### PR TITLE
Forward query parameters to shields.io

### DIFF
--- a/handlers/badge.go
+++ b/handlers/badge.go
@@ -1,9 +1,9 @@
 package handlers
 
 import (
-	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/gojp/goreportcard/check"
@@ -26,26 +26,71 @@ func BadgeHandler(w http.ResponseWriter, r *http.Request, db *badger.DB, repo st
 		return
 	}
 
-	http.Redirect(w, r, badgeURL(resp.Grade, style), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, badgeURL(resp.Grade, r.URL.Query()), http.StatusTemporaryRedirect)
 }
 
-func badgeURL(grade check.Grade, style string) string {
-	var color string
-	switch grade {
-	case check.GradeAPlus:
-		color = "brightgreen"
-	case check.GradeA:
-		color = "green"
-	case check.GradeB:
-		color = "yellowgreen"
-	case check.GradeC:
-		color = "yellow"
-	case check.GradeD:
-		color = "orange"
-	case check.GradeE:
-		fallthrough
-	case check.GradeF:
-		color = "red"
+func badgeURL(grade check.Grade, queryParams url.Values) string {
+	badgeURL, _ := url.ParseRequestURI("https://img.shields.io/static/v1")
+
+	style := queryParams.Get("style")
+	color := queryParams.Get("color")
+	labelColor := queryParams.Get("labelColor")
+	logo := queryParams.Get("logo")
+	logoColor := queryParams.Get("logoColor")
+	logoWidth := queryParams.Get("logoWidth")
+	label := queryParams.Get("label")
+
+	if style == "" {
+		style = "flat"
 	}
-	return fmt.Sprintf("https://img.shields.io/badge/go%%20report-%s-%s.svg?style=%s", grade, color, style)
+
+	if color == "" {
+		switch grade {
+		case check.GradeAPlus:
+			color = "brightgreen"
+		case check.GradeA:
+			color = "green"
+		case check.GradeB:
+			color = "yellowgreen"
+		case check.GradeC:
+			color = "yellow"
+		case check.GradeD:
+			color = "orange"
+		case check.GradeE:
+			fallthrough
+		case check.GradeF:
+			color = "red"
+		}
+	}
+
+	if label == "" {
+		label = "go report"
+	}
+
+	values := badgeURL.Query()
+	values.Set("color", color)
+	values.Set("style", style)
+	values.Set("label", label)
+	values.Set("message", string(grade))
+
+	// optional parameters
+	if labelColor != "" {
+		values.Set("labelColor", labelColor)
+	}
+
+	if logo != "" {
+		values.Set("logo", logo)
+	}
+
+	if logoColor != "" {
+		values.Set("logoColor", logoColor)
+	}
+
+	if logoWidth != "" {
+		values.Set("logoWidth", logoWidth)
+	}
+
+	badgeURL.RawQuery = values.Encode()
+
+	return badgeURL.String()
 }

--- a/handlers/badge_test.go
+++ b/handlers/badge_test.go
@@ -1,28 +1,96 @@
 package handlers
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/gojp/goreportcard/check"
 )
 
 func TestBadgeURL(t *testing.T) {
-	for grade, expectedURL := range map[check.Grade]string{
-		check.GradeAPlus: "https://img.shields.io/badge/go%20report-A+-brightgreen.svg?style=for-the-badge",
-		check.GradeA:     "https://img.shields.io/badge/go%20report-A-green.svg?style=for-the-badge",
-		check.GradeB:     "https://img.shields.io/badge/go%20report-B-yellowgreen.svg?style=for-the-badge",
-		check.GradeC:     "https://img.shields.io/badge/go%20report-C-yellow.svg?style=for-the-badge",
-		check.GradeD:     "https://img.shields.io/badge/go%20report-D-orange.svg?style=for-the-badge",
-		check.GradeE:     "https://img.shields.io/badge/go%20report-E-red.svg?style=for-the-badge",
-		check.GradeF:     "https://img.shields.io/badge/go%20report-F-red.svg?style=for-the-badge",
-	} {
-		grade := grade
-		expectedURL := expectedURL
-		t.Run(string(grade), func(t *testing.T) {
+	cases := []struct {
+		name   string
+		grade  check.Grade
+		params url.Values
+		want   string
+	}{
+		{
+			check.GradeAPlus,
+			check.GradeAPlus,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=brightgreen&label=go+report&message=A%2B&style=flat",
+		},
+		{
+			check.GradeA,
+			check.GradeA,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=green&label=go+report&message=A&style=flat",
+		},
+		{
+			check.GradeB,
+			check.GradeB,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=yellowgreen&label=go+report&message=B&style=flat",
+		},
+		{
+			check.GradeC,
+			check.GradeC,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=yellow&label=go+report&message=C&style=flat",
+		},
+		{
+			check.GradeD,
+			check.GradeD,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=orange&label=go+report&message=D&style=flat",
+		},
+		{
+			check.GradeE,
+			check.GradeE,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=red&label=go+report&message=E&style=flat",
+		},
+		{
+			check.GradeF,
+			check.GradeF,
+			url.Values{},
+			"https://img.shields.io/static/v1?color=red&label=go+report&message=F&style=flat",
+		},
+		{
+			"override style",
+			check.GradeAPlus,
+			url.Values{"style": []string{"for-the-badge"}},
+			"https://img.shields.io/static/v1?color=brightgreen&label=go+report&message=A%2B&style=for-the-badge",
+		},
+		{
+			"override color",
+			check.GradeAPlus,
+			url.Values{"color": []string{"ff69b4"}},
+			"https://img.shields.io/static/v1?color=ff69b4&label=go+report&message=A%2B&style=flat",
+		},
+		{
+			"override logo params",
+			check.GradeAPlus,
+			url.Values{"logo": []string{"go"}, "logoWidth": []string{"100"}, "logoColor": []string{"ff69b4"}},
+			"https://img.shields.io/static/v1?color=brightgreen&label=go+report&logo=go&logoColor=ff69b4&logoWidth=100&message=A%2B&style=flat",
+		},
+		{
+			"override label params",
+			check.GradeAPlus,
+			url.Values{"label": []string{"code quality"}, "labelColor": []string{"0080ff"}},
+			"https://img.shields.io/static/v1?color=brightgreen&label=code+quality&labelColor=0080ff&message=A%2B&style=flat",
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+
+		t.Run(string(tt.name), func(t *testing.T) {
 			t.Parallel()
-			got := badgeURL(grade, "for-the-badge")
-			if got != expectedURL {
-				t.Errorf("expected %s, got %s", expectedURL, got)
+
+			got := badgeURL(tt.grade, tt.params)
+			if got != tt.want {
+				t.Errorf("expected %s, got %s", tt.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
Related issues:
- https://github.com/gojp/goreportcard/issues/304
- https://github.com/gojp/goreportcard/issues/395

Makes the go report badge customizable by forwarding some query string params and keeping the essential ones (like the `message` representing the grade

cc: @shawnps @hermanschaaf 